### PR TITLE
Workaround for Internal Error 2024011501 on FPC [main] (3.3.1) - Now on FPC [main], compilation is successful

### DIFF
--- a/core/dopf.pas
+++ b/core/dopf.pas
@@ -707,7 +707,7 @@ end;
 procedure TdGConnection.CheckBrokerClass;
 begin
   if not T1.InheritsFrom(TdConnectionBroker) then
-    raise EdConnection.CreateFmt('Invalid broker class: "%s".', [T1.ClassName]);
+    raise EdConnection.CreateFmt('Invalid broker class: "%s".', [ShortString(T1.ClassName)]);
 end;
 
 procedure TdGConnection.CheckBroker;
@@ -719,7 +719,7 @@ end;
 procedure TdGConnection.CheckLoggerClass;
 begin
   if not T2.InheritsFrom(TdLogger) then
-    raise EdConnection.CreateFmt('Invalid logger class: "%s".', [T2.ClassName]);
+    raise EdConnection.CreateFmt('Invalid logger class: "%s".', [ShortString(T2.ClassName)]);
 end;
 
 function TdGConnection.GetConnected: Boolean;
@@ -1297,7 +1297,7 @@ end;
 procedure TdGQuery.CheckBrokerClass;
 begin
   if not T1.InheritsFrom(TdQueryBroker) then
-    raise EdQuery.CreateFmt('Invalid broker class: "%s".', [T1.ClassName]);
+    raise EdQuery.CreateFmt('Invalid broker class: "%s".', [ShortString(T1.ClassName)]);
 end;
 
 procedure TdGQuery.CheckBroker;


### PR DESCRIPTION
Hello, this is a known bug in FPC [main]

Previously, it went unnoticed in PPU, even in version 3.2.2, but now it is flagged as an error

This error occurs when arrayf of const and some data from the generic type are used inside the generic—the compiler cannot know the type of the parameter and therefore generates an incorrect type. Previously (before this error was triggered and assigned a number), this code was apparently rarely executed and did not cause any errors

However, there is a very simple workaround: you just need to explicitly specify the type of the constant array element